### PR TITLE
exlcude RubyMine files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /log/*
 !/log/.keep
 /tmp
+
+/.idea/*


### PR DESCRIPTION
The .idea directory holds a bunch of files that have to do with how you are editing your code in RubyMine and are not a part of your code at all. This .gitignore update will keep them out of your git repo moving forward.
